### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/client_libraries/php_library/php-streetview-publish/composer.json
+++ b/client_libraries/php_library/php-streetview-publish/composer.json
@@ -10,7 +10,7 @@
     "google/gax": "0.8.*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.7"
+    "phpunit/phpunit": "^5.7.21"
   },
   "license": "Apache-2.0",
   "autoload": {

--- a/client_libraries/php_library/php-streetview-publish/tests/unit/Streetview/Publish/V1/StreetViewPublishServiceClientTest.php
+++ b/client_libraries/php_library/php-streetview-publish/tests/unit/Streetview/Publish/V1/StreetViewPublishServiceClientTest.php
@@ -26,7 +26,7 @@ use Google\Streetview\Publish\V1\StreetViewPublishServiceClient;
 use Google\GAX\ApiException;
 use Google\GAX\GrpcCredentialsHelper;
 use Grpc;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use google\protobuf\Any;
 use google\protobuf\EmptyC;
 use google\protobuf\FieldMask;
@@ -43,7 +43,7 @@ use stdClass;
  * @group publish
  * @group grpc
  */
-class StreetViewPublishServiceClientTest extends PHPUnit_Framework_TestCase
+class StreetViewPublishServiceClientTest extends TestCase
 {
     public function createMockStreetViewPublishServiceImpl($hostname, $opts)
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just need to bump PHPUnit version to [5.7.21](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#5721---2017-06-21) for compatibility.